### PR TITLE
Ensure tests work when run without the suite

### DIFF
--- a/test/TodoAppTest.jsx
+++ b/test/TodoAppTest.jsx
@@ -28,13 +28,13 @@ describe('TodoMVC App', function() {
   var model, router;
 
   beforeEach(function() {
+    router = new director.Router();
     localStorage.clear();
   });
 
   describe('when the Todo list start off empty', function() {
     beforeEach(function() {
       model = new TodoModel();
-      router = new director.Router();
     });
 
     it('only renders a header when there are no items in the list', function() {


### PR DESCRIPTION
The router needs to be created in the root level `describe()` so tests
from other suites will work when run by themselves.
