### PR TITLE
Use fork of 'teaspoon' library

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "node-inspector": "^0.12.3",
     "react-addons-test-utils": "^0.14.0",
     "sinon": "^1.17.2",
-    "teaspoon": "^5.0.0",
+    "teaspoon": "BladeRunnerJS/teaspoon#shallowRender-state-fix-plus-npm-fixes",
     "unexpected": "^10.0.1",
     "unexpected-react-shallow": "^0.7.0",
     "watch-run": "^1.2.2"

--- a/src/TodoApp.jsx
+++ b/src/TodoApp.jsx
@@ -18,15 +18,18 @@ var TodoApp = React.createClass({
 		};
 	},
 
-	componentDidMount: function () {
+	componentWillMount: function () {
 		var setState = this.setState;
 		this.props.router.mount({
 			'/': setState.bind(this, {nowShowing: ALL_TODOS}),
 			'/active': setState.bind(this, {nowShowing: ACTIVE_TODOS}),
 			'/completed': setState.bind(this, {nowShowing: COMPLETED_TODOS})
 		});
-		this.props.router.init('/');
 		this.props.model.subscribe(this.forceUpdate.bind(this));
+	},
+
+	componentDidMount: function () {
+		this.props.router.init('/');
 	},
 
 	handleTodoAdded: function (todo) {

--- a/test/TodoAppTest.jsx
+++ b/test/TodoAppTest.jsx
@@ -242,11 +242,12 @@ describe('TodoMVC App', function() {
       );
     });
 
-    xit('updates the footer information when the completed filter is clicked', function() {
+    it('updates the footer information when the completed filter is clicked', function() {
       // given
       var todoApp = $(<TodoApp model={model} router={router}/>);
 
       // when
+      todoApp.shallowRender();
       router.dispatch('on', '/completed');
 
       // then


### PR DESCRIPTION
This allows `shallowRender()` to be used to test state changes within
components. We also had to move the router intialization code from
`componentDidMount()` to `componentWillMount()`, since
`componentDidMount()` never fires when `shallowRender()` is used.
